### PR TITLE
disable mutations added

### DIFF
--- a/type/mutation.js
+++ b/type/mutation.js
@@ -436,18 +436,58 @@ const MutationType = new GraphQLObjectType({
             });
         }
       },
+      disableBranch: {
+        type: Branch,
+        args: {
+          id: {
+            type: new GraphQLNonNull(GraphQLID)
+          }
+        },
+        resolve(roots, args) {
+          return Db.models.branch
+            .findOne({ where: { id: args.id } })
+            .then(result => {
+              args.active = !result.dataValues.active;
+              return result
+                .update(args, { returning: true })
+                .then(updatedresult => {
+                  return updatedresult;
+                });
+            });
+        }
+      },
       disableEmployee: {
         type: Employee,
         args: {
           user: {
-            type: GraphQLString
+            type: new GraphQLNonNull(GraphQLString)
           }
         },
         resolve(roots, args) {
-          args.active = false;
           return Db.models.employee
             .findOne({ where: { user: args.user } })
             .then(result => {
+              args.active = !result.dataValues.active;
+              return result
+                .update(args, { returning: true })
+                .then(updatedresult => {
+                  return updatedresult;
+                });
+            });
+        }
+      },
+      disableServiceshift: {
+        type: ServiceShift,
+        args: {
+          id: {
+            type: new GraphQLNonNull(GraphQLID)
+          }
+        },
+        resolve(roots, args) {
+          return Db.models.serviceshift
+            .findOne({ where: { id: args.id } })
+            .then(result => {
+              args.active = !result.dataValues.active;
               return result
                 .update(args, { returning: true })
                 .then(updatedresult => {


### PR DESCRIPTION
Linked with issue #25 

Mutations have been created to handle active boolean values

Branch:
- [x] Disable action needs id as input argument

Employee:
- [x] Disable action needs user as input argument

Serviceshift:
- [x] Disable action needs id as input argument

